### PR TITLE
Clean up actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,9 +6,9 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
+        node-version-file: .node-version
         cache: npm
-        cache-dependency-path: ./package.json
 
     - name: Install dependencies
-      run: npm install
+      run: npm ci
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## tl;dr

Tighten up CI: pin Node to match local dev, use `npm ci`, and scope down permissions

## What changed?

- `actions/setup-node` now reads `.node-version` via `node-version-file`, so CI runs on the same Node we use locally (24.14.0) instead of whatever `ubuntu-latest` happens to ship.
- Dropped `cache-dependency-path: ./package.json`. `cache: npm` already defaults to `package-lock.json` at the repo root, which is what we actually want the cache keyed on.
- Swapped `npm install` for `npm ci` in the setup composite action.
- Added a top-level `permissions: contents: read` block to `ci.yml`.

## Why?

Fix up a bunch of small papercuts.