### PR TITLE
Type public method returns as Arrival[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **Types:** Typed public method returns as `Arrival[]` instead of `unknown`, and exported the `Arrival` type. Consumers no longer need to cast the result of `getArrivalsForStation`, `getArrivalsForStop`, or `followTrain`.
+
 ## 4.3.0
 
 - Replaced luxon with dateline for time formatting

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { request } from "node:https";
 import { parseTrain } from "./parsers/train.js";
 import { APIResponse } from "./types/responses.js";
 
+export type Arrival = ReturnType<typeof parseTrain>;
+
 const API_BASE_URL = "lapi.transitchicago.com";
 const API_BASE_PATH = "/api/1.0";
 const PKG_VERSION = "4.2.0";
@@ -14,15 +16,21 @@ export default class SlowZone {
     this.apiKey = options.apiKey;
   }
 
-  getArrivalsForStation(stationId: string | number, options = {}) {
+  getArrivalsForStation(
+    stationId: string | number,
+    options = {},
+  ): Promise<Arrival[]> {
     return this.getArrivals({ ...options, mapid: stationId });
   }
 
-  getArrivalsForStop(stopId: string | number, options = {}) {
+  getArrivalsForStop(
+    stopId: string | number,
+    options = {},
+  ): Promise<Arrival[]> {
     return this.getArrivals({ ...options, stpid: stopId });
   }
 
-  followTrain(runId: string | number) {
+  followTrain(runId: string | number): Promise<Arrival[]> {
     return this.fetch("ttfollow.aspx", { runnumber: runId });
   }
 
@@ -30,9 +38,9 @@ export default class SlowZone {
     return this.fetch("ttarrivals.aspx", options);
   }
 
-  private async fetch(endpoint: string, queryParams = {}) {
+  private async fetch(endpoint: string, queryParams = {}): Promise<Arrival[]> {
     return this.makeRequest(endpoint, queryParams).then((resp) => {
-      return new Promise((resolve, reject) => {
+      return new Promise<Arrival[]>((resolve, reject) => {
         if (!resp) {
           reject(new Error("invalid response"));
         }


### PR DESCRIPTION
## tl;dr

The three public methods on `SlowZone` now return `Promise<Arrival[]>` instead of `Promise<unknown>`. Consumers can drop their `as Arrival[]` casts.

## What changed?

- Added an exported `Arrival` type derived from the parser's return shape (`ReturnType<typeof parseTrain>`).
- Annotated `getArrivalsForStation`, `getArrivalsForStop`, and `followTrain` with `Promise<Arrival[]>`. The explicit annotation also keeps the generated `.d.ts` referencing `Arrival` by name rather than inlining the full object literal three times.
- Threaded the type through the private `fetch` method and added the missing generic to the inner `new Promise<Arrival[]>(...)` — that's where the leak to `unknown` originated.

No runtime behavior change; the existing parser snapshot tests pass without modification.

## Why?

`fetch()` constructed its inner Promise without a generic argument, so `resolve` defaulted to `(value: unknown) => void` and the resolved type bubbled up to `unknown` on every public method. That forced every TS consumer to cast — slow-zone-web has both inline `(await client.followTrain(runId)) as Arrival[]` and hand-rolled `LoaderData` types asserting `arrivals: Arrival[]`. The SDK already knew the shape; it just wasn't exposing it.

Narrowing `unknown` → `Arrival[]` doesn't break JS consumers, and existing TS casts remain valid (redundant but compiling), so this can land as a minor bump rather than a major.