### PR TITLE
Read User-Agent version from package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **Types:** Typed public method returns as `Arrival[]` instead of `unknown`, and exported the `Arrival` type. Consumers no longer need to cast the result of `getArrivalsForStation`, `getArrivalsForStop`, or `followTrain`.
+- **Bug:** Fixed the `User-Agent` header to report the actual package version. It was hardcoded to `slow-zone/4.2.0` in 4.3.0. The version is now read from `package.json` at load time and exported as `VERSION`.
 
 ## 4.3.0
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { request, type RequestOptions } from "node:https";
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import SlowZone, { VERSION } from "./index.js";
+
+vi.mock("node:https", () => ({
+  request: vi.fn(),
+}));
+
+const mockRequest = vi.mocked(request);
+
+describe("SlowZone", () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  test("VERSION matches package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+    );
+    expect(VERSION).toBe(pkg.version);
+  });
+
+  test("sends a User-Agent header with the package version", () => {
+    const mockReq = { on: vi.fn(), end: vi.fn() } as unknown as ReturnType<
+      typeof request
+    >;
+    mockRequest.mockReturnValue(mockReq);
+
+    const client = new SlowZone({ apiKey: "test-key" });
+    void client.getArrivalsForStation(41020);
+
+    expect(mockRequest).toHaveBeenCalledOnce();
+    const options = mockRequest.mock.calls[0][0] as RequestOptions;
+    expect(options.headers?.["User-Agent"]).toBe(`slow-zone/${VERSION}`);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { request } from "node:https";
 
 import { parseTrain } from "./parsers/train.js";
@@ -7,7 +8,9 @@ export type Arrival = ReturnType<typeof parseTrain>;
 
 const API_BASE_URL = "lapi.transitchicago.com";
 const API_BASE_PATH = "/api/1.0";
-const PKG_VERSION = "4.2.0";
+export const VERSION: string = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+).version;
 
 export default class SlowZone {
   apiKey: string;
@@ -70,7 +73,7 @@ export default class SlowZone {
       method: "GET",
       headers: {
         Accept: "application/json",
-        "User-Agent": `slow-zone/${PKG_VERSION}`,
+        "User-Agent": `slow-zone/${VERSION}`,
       },
     };
 


### PR DESCRIPTION
## tl;dr

The `User-Agent` header sent with every CTA API request now carries the actual installed package version. Also exposes a new `VERSION` public export.

## What changed?

The `User-Agent` string used to come from a hardcoded `PKG_VERSION` constant in `src/index.ts`. That's been replaced with a runtime read of `package.json`:

```ts
export const VERSION: string = JSON.parse(
  readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
).version;
```

`new URL("../package.json", import.meta.url)` resolves to the package root from both `src/index.ts` and the published `dist/index.js`, so no build-time wiring is needed. `VERSION` is exported alongside `Arrival`; the header template is now `slow-zone/${VERSION}`.

There's a new `src/index.test.ts` with two tests: one compares `VERSION` to `package.json.version` as a drift guard (also catches regressions in path resolution), and one stubs `node:https.request` and asserts the header value on the options passed to it — no network.

## Why?

The hardcoded constant had drifted: 4.3.0 shipped sending `slow-zone/4.2.0` on every request. No real consumer impact, but the header was misleading in server logs and any downstream telemetry that parses it. Reading from `package.json` at module load eliminates the class of drift entirely.

Exposing `VERSION` as a public export made the UA testable without poking at module internals, and is genuinely useful for consumer diagnostics.
