### PR TITLE
Flatten fetch() to async/await

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,18 +42,14 @@ export default class SlowZone {
   }
 
   private async fetch(endpoint: string, queryParams = {}): Promise<Arrival[]> {
-    return this.makeRequest(endpoint, queryParams).then((resp) => {
-      return new Promise<Arrival[]>((resolve, reject) => {
-        if (!resp) {
-          reject(new Error("invalid response"));
-        }
-        if (resp.ctatt.errCd != "0") {
-          return reject(new Error(`[${resp.ctatt.errCd}] ${resp.ctatt.errNm}`));
-        }
-
-        resolve(resp.ctatt.eta.map((trainData) => parseTrain(trainData)));
-      });
-    });
+    const resp = await this.makeRequest(endpoint, queryParams);
+    if (!resp) {
+      throw new Error("invalid response");
+    }
+    if (resp.ctatt.errCd != "0") {
+      throw new Error(`[${resp.ctatt.errCd}] ${resp.ctatt.errNm}`);
+    }
+    return resp.ctatt.eta.map((trainData) => parseTrain(trainData));
   }
 
   private async makeRequest(


### PR DESCRIPTION
## tl;dr

`fetch()` is now plain async/await instead of a `.then()` chain wrapping a nested `new Promise(...)`.

## What changed?

`fetch()` used to be `async` wrapping `makeRequest(...).then(resp => new Promise((resolve, reject) => {...}))`. The inner `new Promise` executor did only synchronous work — a falsy-resp check, an error-code check, and a `.map()` over `ctatt.eta`. Flattened to `await` + early `throw`s: `resolve(x)` becomes `return x`, `reject(e)` becomes `throw e`.

## Why?

The nested `new Promise(...)` is the construct that hid the missing generic responsible for the original `Promise<unknown>` leak fixed in the previous PR. Flattening means the function return annotation is the single source of truth for what consumers see, and there's no false implication that something async happens inside the outer `.then()`.